### PR TITLE
Undoes fractioning of reactions.

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -502,7 +502,7 @@
 					return 0
 
 				for(var/B in cached_required_reagents) //
-					multiplier = min(multiplier, round((get_reagent_amount(B) / cached_required_reagents[B]), CHEMICAL_QUANTISATION_LEVEL))
+					multiplier = min(multiplier, round(get_reagent_amount(B) / cached_required_reagents[B]))
 
 				for(var/B in cached_required_reagents)
 					remove_reagent(B, (multiplier * cached_required_reagents[B]), safety = 1, ignore_pH = TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Upstream we were testing fractionised reactions, when the testmerge got full merged. As it was found out later this doesn't play well with cooking reactions, so we've got a testmerge to tweak this, but I know you guys have testruns today, and I didn't want you guys to be stuck with broken cooking, so I figured I'd bring this over to you.

## Why It's Good For The Game

Allows cooking reactions to not disappear and produce nothing.

## Changelog
:cl: Fermis
fix: returns standard reactions to their normal ratios and fixes cooking reactions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
